### PR TITLE
Update example code solidity version to 0.5.12

### DIFF
--- a/src/editor-solidity.js
+++ b/src/editor-solidity.js
@@ -104,7 +104,7 @@ Paste it in the editor and wait for the preview to start interacting with it.
 */
 
 
-pragma solidity 0.5.9;
+pragma solidity 0.5.12;
 
 contract SimpleStorage {
 


### PR DESCRIPTION
Somehow version 0.5.9 of the compiler doesn't want to load:
Access to fetch at 'https://solc-bin.ethereum.org/bin/soljson-v0.5.9+commit.c68bc34e.js' from origin 'https://playproject.io' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.

However version 0.5.12 does load. Therefore i've made a minor update to the sample contract with version 0.5.12